### PR TITLE
refactor(github/workflows): GitHub workflows improvement

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: The documentation lint to source codes.
 on:
   pull_request:
     branches: ["*"]
-    paths: &target
+    paths:
       # workflows
       - ".github/workflows/docs.yml"
       # source code
@@ -17,7 +17,17 @@ on:
   push:
     branches:
       - main
-    paths: *target
+    paths:
+      # workflows
+      - ".github/workflows/docs.yml"
+      # source code
+      - "src/**"
+      # configuration files
+      - "eslint.config.mjs"
+      - "tsconfig.json"
+      # packages
+      - "bun.lock"
+      - "package.json"
 
 jobs:
   jsdoc:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: The source code lint by biome.
 on:
   pull_request:
     branches: ["*"]
-    paths: &target
+    paths:
       # workflows
       - ".github/workflows/lint.yml"
       # source code
@@ -18,7 +18,18 @@ on:
   push:
     branches:
       - main
-    paths: *target
+    paths:
+      # workflows
+      - ".github/workflows/lint.yml"
+      # source code
+      - "live/**"
+      - "src/**"
+      # configuration files
+      - "biome.json"
+      - "tsconfig.json"
+      # package
+      - "bun.lock"
+      - "package.json"
 
 jobs:
   biome:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Running tests by vitest.
 on:
   pull_request:
     branches: ["*"]
-    paths: &target
+    paths:
       # workflows
       - ".github/workflows/test.yml"
       # source code
@@ -19,8 +19,19 @@ on:
   push:
     branches:
       - main
-    pull_request:
-      paths: *target
+    paths:
+      # workflows
+      - ".github/workflows/test.yml"
+      # source code
+      - "src/**"
+      # configuration files
+      - "tsconfig.json"
+      - "vitest.config.ts"
+      - "worker-configuration.d.ts"
+      - "wrangler.jsonc"
+      # package
+      - "bun.lock"
+      - "package.json"
 
 jobs:
   vitest:


### PR DESCRIPTION
## Context

Currentlly, all workflow files does not triggered by update to `bun.lock` or `package.json`,
these workflows should be triggered by `bun.lock` or `package.json`.

~And, all workflow files uses same target on `push` and `pull_request` section,
but this configuration describe to twice in same files.~

So this pull request has rewriting  for these problems.

**Edit**: GitHub Actions does not support yaml ancher.

## Status

- [ ] Draft
- [ ] Proposal
- [x] Approved
- [ ] Reject

## Decision

- Add `package.json` and `bun.lock` to workflow trigger target
- ~Use ancher yaml feature for simplified yaml files~
- More readable code on workflow yaml

## Effected Scope

- If it has mistake, workflows broken.