### PR TITLE
feat(middleware/response-cache{,-r2}): automatic cache on these middlewares

### DIFF
--- a/src/middlewares/by-name/re/response-cache-r2.test.ts
+++ b/src/middlewares/by-name/re/response-cache-r2.test.ts
@@ -58,7 +58,12 @@ describe("response-cache-r2", () => {
             ? new Response("/foo")
             : undefined;
         },
-        async put(_: Request, __: Response) {
+        async put(key: Request, value: Response) {
+          expect(key).toBeInstanceOf(Request);
+          expect(key.bodyUsed).toBeFalsy();
+
+          expect(value).toBeInstanceOf(Response);
+          expect(value.bodyUsed).toBeFalsy();
           return;
         },
         async delete(_: Request) {

--- a/src/middlewares/by-name/re/response-cache-r2.ts
+++ b/src/middlewares/by-name/re/response-cache-r2.ts
@@ -115,4 +115,13 @@ export const middleware =
     }
 
     await next();
+
+    const request = c.req.raw.clone();
+    const response = c.res.clone();
+
+    try {
+      c.executionCtx.waitUntil(cache.put(request, response));
+    } catch (e) {
+      await cache.put(request, response);
+    }
   };

--- a/src/middlewares/by-name/re/response-cache.test.ts
+++ b/src/middlewares/by-name/re/response-cache.test.ts
@@ -8,7 +8,12 @@ describe("response-cache", () => {
   const dummryCacheOpener = async (key: string): Promise<ICache> => ({
     match: async (_: Request) =>
       "/foo" === key ? new Response(key, { status: 200 }) : undefined,
-    put: (_: Request, __: Response) => {
+    put: (key: Request, value: Response) => {
+      expect(key).toBeInstanceOf(Request);
+      expect(key.bodyUsed).toBeFalsy();
+
+      expect(value).toBeInstanceOf(Response);
+      expect(value.bodyUsed).toBeFalsy();
       return;
     },
     delete: (_: Request) => true,

--- a/src/middlewares/by-name/re/response-cache.ts
+++ b/src/middlewares/by-name/re/response-cache.ts
@@ -32,4 +32,13 @@ export const middleware =
     }
 
     await next();
+
+    const request = c.req.raw.clone();
+    const response = c.res.clone();
+
+    try {
+      c.executionCtx.waitUntil(cache.put(request, response));
+    } catch (e) {
+      await cache.put(request, response);
+    }
   };


### PR DESCRIPTION
## Context

These middlewares uses response from cache,
But these middlewares does not set response to cache.

So this pull request adds features to set response cache to automatic.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- `response-cache{,-r2}` set response to cache automatic.

## Effected Scope

- The applications uses these middlewares, application does not needs to write cache code by self.
