### PR TITLE
fix(github/workflows): use `bun run` instead of `bunx`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,4 +42,4 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Lint by eslint
-        run: bunx eslint
+        run: bun run eslint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,4 +44,4 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Lint by biome
-        run: bunx biome check live src
+        run: bun run biome check live src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test with bun and vitest
-        run: bunx vitest -- --dir src 
+        run: bun run vitest -- --dir src


### PR DESCRIPTION
## Context

At the moment, CI by GitHub Actions runs *live* tests, but these tests should running on local development environment.

This pull request fix to this issue.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- Use `bun run` instead of `bunx` for fix to the live test issue.

## Effected Scope

- CI tasks runs by `bun run`
- If this fix has issue, CI tasks is broken