### PR TITLE
refactor(husky/pre-commit): improve `.huskey/pre-commit` hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 bun run biome format --write live
 bun run biome format --write src
 
-bun run biome lint live
-bun run biome lint src
+bun run biome check live src


### PR DESCRIPTION
## Context

Currently, the linting method is different when CI test between pre-commit check.  The CI test uses `biome check`, but pre-commit uses `biome lint`.

This pull request changes to uses `biome check` when CI and pre-commit hook.

In addition, pre-commit uses `bun run` to runs toolchains. This is same way to the CI by GitHub Actions.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- The pre-commit hook uses `biome check` as pre-commit linting
- The pre-commit hook uses `bun run` as toolchain runner

## Effected Scope

- If the pre-commit hook has some mistake, all commiting failed when local development