### PR TITLE
chore(flake): update nix flake at 2025-06-22

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748856973,
-        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "lastModified": 1750386251,
+        "narHash": "sha256-1ovgdmuDYVo5OUC5NzdF+V4zx2uT8RtsgZahxidBTyw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "rev": "076e8c6678d8c54204abcb4b1b14c366835a58bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Context

the `flake.lock` file is old, so update to latest `nixpkgs-unstable`.

## Status

- [ ] Draft
- [ ] Proposal
- [x] Approved
- [ ] Reject

## Decision

- Update `flake.lock` at 2025-06-22

## Effected Scope

- On local development with nix flake
