### PR TITLE
feat(image-line): add support to flstudio-new

### DIFF
--- a/examples/customfeed/index.ts
+++ b/examples/customfeed/index.ts
@@ -1,0 +1,34 @@
+import { Hono } from "hono";
+
+import type { Bindings as basicAuthBindings } from "@/middlewares/by-name/ba/basic-auth";
+import type { Bindings as r2ResponseCacheBindings } from "@/middlewares/by-name/re/response-cache-r2";
+
+import { middleware as basicAuthMiddleware } from "@/middlewares/by-name/ba/basic-auth";
+import { middleware as responseCacheMiddleware } from "@/middlewares/by-name/re/response-cache";
+import { middleware as r2ResponseCacheMiddleware } from "@/middlewares/by-name/re/response-cache-r2";
+
+import { R2Cache } from "@/middlewares/by-name/re/response-cache-r2";
+
+import { FLStudioNewsToJSONFeed } from "@/services/by-name/im/image-line/handlers";
+
+type Bindings = {} & basicAuthBindings & r2ResponseCacheBindings;
+
+const cacheOpener = (ns: string) => caches.open(`response:${ns}`);
+const R2CacheOpener = (bucket: R2Bucket, duration: number) =>
+  R2Cache(bucket, duration, (r: Request) => new URL(r.url).pathname);
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.use(
+  "*",
+  basicAuthMiddleware(),
+  responseCacheMiddleware(cacheOpener),
+  r2ResponseCacheMiddleware(R2CacheOpener),
+);
+
+app.get(
+  "/by-name/im/image-line/flstudio-news.json",
+  FLStudioNewsToJSONFeed("https://customfeed.thotep.net"),
+);
+
+export default app;

--- a/examples/customfeed/wrangler.jsonc
+++ b/examples/customfeed/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "name": "customfeed",
+  "main": "index.ts",
+  "compatibility_date": "2025-03-16",
+  "r2_buckets": [{
+    "binding": "EDGEFEED_R2_CACHE_BUCKET",
+    "bucket_name": "edgefeed-customfeed-cache"
+  }],
+  "vars": {
+    "EDGEFEED_R2_CACHE_DURATION": 1800000 // 60 * 30 * 1000ms
+  }
+}

--- a/live/services/by-name/im/image-line/.gitignore
+++ b/live/services/by-name/im/image-line/.gitignore
@@ -1,0 +1,1 @@
+data.html

--- a/live/services/by-name/im/image-line/Makefile
+++ b/live/services/by-name/im/image-line/Makefile
@@ -1,0 +1,2 @@
+fixture:
+	curl -A "Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0" -L -o data.html "https://www.image-line.com/fl-studio-news"

--- a/live/services/by-name/im/image-line/handler.test.ts
+++ b/live/services/by-name/im/image-line/handler.test.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+import { FLStudioNewsToJSONFeed } from "../../../../../src/services/by-name/im/image-line/handlers";
+
+const app = new Hono();
+app.get("/", FLStudioNewsToJSONFeed("https://example.com/"));
+
+describe("flstudio-news/handlers", () => {
+  it("live request", async () => {
+    const res = await app.request("/", {}, {});
+
+    expect(res.ok).toBeTruthy();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "application/feed+json; charset=utf-8",
+    );
+    expect(await res.json()).toBeTruthy();
+  });
+});

--- a/live/services/by-name/im/image-line/parse.test.ts
+++ b/live/services/by-name/im/image-line/parse.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import data from "./data.html";
+
+import { transformToJSONFeed } from "../../../../../src/services/by-name/im/image-line/parse";
+
+describe("jsonfeed live test", async () => {
+  const input = new Response(data, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+
+  const json = await transformToJSONFeed(
+    input,
+    "https://example.com/flstudio-news",
+  );
+
+  const payload = JSON.parse(json);
+
+  it("jsonfeed version is 1.1", () => {
+    expect(payload.version).toBe("https://jsonfeed.org/version/1.1");
+  });
+
+  it("title is not empty", () => {
+    expect(payload.title).toBeTruthy();
+  });
+
+  it("language is `en-US`", () => {
+    expect(payload.language).toBe("en-US");
+  });
+
+  it("home_page_url is not empty", () => {
+    expect(payload.home_page_url).toBeTruthy();
+  });
+
+  it("feed_url is not empty", () => {
+    expect(payload.feed_url).toBeTruthy();
+  });
+
+  it("for items tests", () => {
+    expect(payload.items.length).greaterThan(0);
+    for (const item of payload.items) {
+      expect(item.title).toBeTruthy();
+      expect(item.id).toBeTruthy();
+      expect(item.url).toBeTruthy();
+      expect(item.date_published).toMatch(
+        /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/,
+      );
+
+      expect(
+        !("banner_image" in item) || item.banner_image.match(/^https:\/\//),
+      ).toBeTruthy();
+
+      expect(item.summary).toBeTruthy();
+
+      expect(item.tags.length).greaterThan(0);
+    }
+  });
+});

--- a/live/services/by-name/im/image-line/parse.test.ts
+++ b/live/services/by-name/im/image-line/parse.test.ts
@@ -52,7 +52,7 @@ describe("jsonfeed live test", async () => {
         !("banner_image" in item) || item.banner_image.match(/^https:\/\//),
       ).toBeTruthy();
 
-      expect(item.summary).toBeTruthy();
+      expect(item.content_html).toBeTruthy();
 
       expect(item.tags.length).greaterThan(0);
     }

--- a/live/services/by-name/im/image-line/parse.test.ts
+++ b/live/services/by-name/im/image-line/parse.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
-import data from "./data.html";
-
 import { transformToJSONFeed } from "../../../../../src/services/by-name/im/image-line/parse";
+import data from "./data.html";
 
 describe("jsonfeed live test", async () => {
   const input = new Response(data, {

--- a/src/services/by-name/im/image-line/handlers.ts
+++ b/src/services/by-name/im/image-line/handlers.ts
@@ -1,0 +1,22 @@
+import type { Context, Handler } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+import { transformToJSONFeed } from "./parse";
+import { makeFLStudioNewRequest } from "./request";
+
+export const FLStudioNewsToJSONFeed =
+  (baseUrl: string, userAgent?: string): Handler =>
+  async (c: Context) => {
+    const request = makeFLStudioNewRequest(userAgent);
+    const response = await fetch(request);
+
+    if (!response?.ok) {
+      throw new HTTPException(500, {
+        message: `failed to fetch flstudio-news page: ${await response.text()}`,
+      });
+    }
+
+    return c.body(await transformToJSONFeed(response, baseUrl), 200, {
+      "Content-Type": "application/feed+json; charset=utf-8",
+    });
+  };

--- a/src/services/by-name/im/image-line/handlers.ts
+++ b/src/services/by-name/im/image-line/handlers.ts
@@ -4,6 +4,13 @@ import { HTTPException } from "hono/http-exception";
 import { transformToJSONFeed } from "./parse";
 import { makeFLStudioNewRequest } from "./request";
 
+/**
+ * Make `Hono` handler for transform flstudio-news page to JSON feed.
+ *
+ * @param {string} baseUrl - the string of base URL on JSON feed.
+ * @param {string?} userAgent - the custom User-Agent string to fetch content.
+ * @returns {Handler}-- the Hono handler.
+ */
 export const FLStudioNewsToJSONFeed =
   (baseUrl: string, userAgent?: string): Handler =>
   async (c: Context) => {

--- a/src/services/by-name/im/image-line/parse.ts
+++ b/src/services/by-name/im/image-line/parse.ts
@@ -232,7 +232,7 @@ export class JSONFeedTransformer {
       "title": "${t(this.title)}",
       "id": "${t(this.href)}",
       "url": "${t(this.href)}",
-      "summary": "${t(this.summary)}",
+      "content_html": "${t(this.summary)}",
       ${thumbnail}
       ${tags}
       "date_published": "${this.date}"

--- a/src/services/by-name/im/image-line/parse.ts
+++ b/src/services/by-name/im/image-line/parse.ts
@@ -1,5 +1,3 @@
-import { FLStudioNewsUrl } from "./request";
-
 enum Property {
   Unknown = 0,
   Date = 1,

--- a/src/services/by-name/im/image-line/parse.ts
+++ b/src/services/by-name/im/image-line/parse.ts
@@ -1,0 +1,277 @@
+import { FLStudioNewsUrl } from "./request";
+
+enum Property {
+  Unknown = 0,
+  Date = 1,
+  Href = 2,
+  Summary = 3,
+  Featured = 5,
+  Tag = 6,
+  Page = 100,
+  Container = 101,
+  Tags = 102,
+}
+
+/**
+ * Escape string for JSON.
+ *
+ * @param {string} src - the raw string.
+ * @returns {string} - the escaped string from raw.
+ */
+export const t = (src: string): string =>
+  src
+    ? src
+        .replace(/\t+/g, " ")
+        // biome-ignore lint/suspicious/noControlCharactersInRegex: this code remove unsafe string from `src`
+        .replace(/[\u0000-\u001F]/g, "")
+        .replace(/(["'\\])/g, (_, p1) => `\\${p1}`)
+    : "";
+
+export class JSONFeedTransformer {
+  private baseUrl = "";
+
+  private state: Property[] = [];
+
+  private pageTitle = "";
+  private pageUrl = "";
+
+  private thumbnail = "";
+  private date = "";
+  private title = "";
+  private href = "";
+  private summary = "";
+  private tags: string[] = [];
+
+  private entries: string[] = [];
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  element(el: Element) {
+    const classNames = el.getAttribute("class");
+
+    switch (el.tagName) {
+      case "title": {
+        this.state.push(Property.Page);
+
+        break;
+      }
+
+      case "link": {
+        if (el.getAttribute("rel") === "canonical") {
+          const href = el.getAttribute("href");
+          if (href) {
+            this.pageUrl = href;
+          }
+        }
+
+        break;
+      }
+
+      case "div": {
+        if (classNames?.startsWith("c-post__content")) {
+          if (this.state.at(-1) === Property.Tags) {
+            this.state.pop();
+          }
+
+          if (this.href === "") {
+            this.state.push(Property.Container);
+          } else {
+            this.emitEntry();
+          }
+          break;
+        }
+
+        if (classNames?.startsWith("c-post__excerpt")) {
+          this.state.push(Property.Summary);
+          el.onEndTag(() => {
+            this.state.pop();
+          });
+          break;
+        }
+
+        if (classNames?.startsWith("c-post__featured")) {
+          this.state.push(Property.Featured);
+          el.onEndTag(() => {
+            this.state.pop();
+          });
+        }
+        break;
+      }
+
+      case "span": {
+        if (this.state.at(-1) === Property.Container) {
+          this.state.push(Property.Date);
+          el.onEndTag(() => {
+            if (this.state.at(-1) === Property.Date) {
+              this.state.pop();
+            }
+          });
+        }
+        break;
+      }
+
+      case "a": {
+        if (this.state.at(-1) === Property.Tags) {
+          this.state.push(Property.Tag);
+          el.onEndTag(() => {
+            this.state.pop();
+          });
+        }
+
+        if (el.getAttribute("data-article-title")) {
+          const title = el.getAttribute("data-article-title");
+          const href = el.getAttribute("href");
+
+          if (title && href) {
+            this.title = title;
+            this.href = href;
+          }
+          break;
+        }
+
+        break;
+      }
+
+      case "img": {
+        const src = el.getAttribute("data-lazy-src");
+        if (src) {
+          this.thumbnail = src;
+        }
+        break;
+      }
+
+      case "h4": {
+        this.state.push(Property.Tags);
+        break;
+      }
+    }
+  }
+
+  text(t: Text) {
+    const text = t.text.replace(/^\s*|\s*$/g, "");
+    if (text === "") {
+      return;
+    }
+
+    switch (this.state.at(-1)) {
+      case Property.Page: {
+        this.pageTitle = text;
+        break;
+      }
+
+      case Property.Summary: {
+        if (text.match(/[^\s]/) && !this.summary.endsWith(text)) {
+          this.summary += this.summary === "" ? text : ` ${text}`;
+        }
+        break;
+      }
+
+      case Property.Featured: {
+        if (text.match(/[^\s]/) && !this.summary.endsWith(text)) {
+          this.summary += this.summary === "" ? text : ` ${text}`;
+        }
+
+        break;
+      }
+
+      case Property.Date: {
+        const match = text.match(/(\d{2})-(\d{2})-(\d{4})/);
+        if (match) {
+          const [_, day, month, year] = match;
+          this.date = `${year}-${month}-${day}T00:00:00Z`;
+        }
+
+        break;
+      }
+
+      case Property.Tag: {
+        this.tags.push(text);
+        break;
+      }
+    }
+  }
+
+  emitEntry() {
+    const thumbnail =
+      this.thumbnail !== "" ? `"banner_image": "${t(this.thumbnail)}",` : "";
+
+    const tags =
+      this.tags.length > 0
+        ? `"tags": [ ${Array.from(new Set(this.tags))
+            .map((x) => `"${t(x)}"`)
+            .join(", ")} ],`
+        : "";
+
+    const entryJSON = `{
+      "title": "${t(this.title)}",
+      "id": "${t(this.href)}",
+      "url": "${t(this.href)}",
+      "summary": "${t(this.summary)}",
+      ${thumbnail}
+      ${tags}
+      "date_published": "${this.date}"
+    }`;
+
+    this.entries.push(entryJSON);
+
+    this.thumbnail = "";
+    this.date = "";
+    this.href = "";
+    this.summary = "";
+    this.tags = [];
+  }
+
+  finalize(): string {
+    this.emitEntry();
+
+    const title = t(this.pageTitle);
+    const home_page_url = t(this.pageUrl);
+    const feed_url = t(this.baseUrl);
+
+    const entries = `${this.entries.join(",\n    ")}`;
+    return `{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "${title}",
+  "language": "en-US",
+  "home_page_url": "${home_page_url}",
+  "feed_url": "${feed_url}",
+  "items": [
+    ${entries}
+  ]
+}`;
+  }
+
+  async transform(input: Response): Promise<string> {
+    let rewriter = new HTMLRewriter();
+
+    const selectors = [
+      "title",
+      `link[rel="canonical"]`,
+
+      ".c-post .c-post__image img[data-lazy-src]",
+      ".c-post .c-post__content",
+      ".c-post .c-post__content > span:first-child",
+      ".c-post .c-post__content > .h3 > a[data-article-title]",
+
+      ".c-post .c-post__content > .c-post__featured",
+      ".c-post .c-post__content > .c-post__excerpt",
+
+      ".c-post .c-post__content > div > h4",
+      ".c-post .c-post__content > div > a",
+    ];
+
+    for (const selector of selectors) {
+      rewriter = rewriter.on(selector, this);
+    }
+
+    await rewriter.transform(input).text();
+    return this.finalize();
+  }
+}
+
+export const transformToJSONFeed = (
+  input: Response,
+  baseUrl: string,
+): Promise<string> => new JSONFeedTransformer(baseUrl).transform(input);

--- a/src/services/by-name/im/image-line/parse.ts
+++ b/src/services/by-name/im/image-line/parse.ts
@@ -39,6 +39,8 @@ export class JSONFeedTransformer {
   private pageUrl = "";
 
   private thumbnail = "";
+  private thumbnailWidth = "";
+  private thumbnailHeight = "";
   private date = "";
   private title = "";
   private href = "";
@@ -150,8 +152,12 @@ export class JSONFeedTransformer {
 
       case "img": {
         const src = el.getAttribute("data-lazy-src");
-        if (src) {
+        const width = el.getAttribute("width");
+        const height = el.getAttribute("height");
+        if (src && width && height) {
           this.thumbnail = src;
+          this.thumbnailWidth = width;
+          this.thumbnailHeight = height;
         }
         break;
       }
@@ -219,7 +225,11 @@ export class JSONFeedTransformer {
    */
   emitEntry() {
     const thumbnail =
-      this.thumbnail !== "" ? `"banner_image": "${t(this.thumbnail)}",` : "";
+      this.thumbnail !== ""
+        ? t(
+            `<p><a href="${this.href}"><img src="${this.thumbnail}" width="${this.thumbnailWidth}" height="${this.thumbnailHeight}" /></a></p>`,
+          )
+        : "";
 
     const tags =
       this.tags.length > 0
@@ -232,8 +242,7 @@ export class JSONFeedTransformer {
       "title": "${t(this.title)}",
       "id": "${t(this.href)}",
       "url": "${t(this.href)}",
-      "content_html": "${t(this.summary)}",
-      ${thumbnail}
+      "content_html": "${thumbnail}${t(this.summary)}",
       ${tags}
       "date_published": "${this.date}"
     }`;

--- a/src/services/by-name/im/image-line/parse.ts
+++ b/src/services/by-name/im/image-line/parse.ts
@@ -27,6 +27,9 @@ export const t = (src: string): string =>
         .replace(/(["'\\])/g, (_, p1) => `\\${p1}`)
     : "";
 
+/**
+ * The transformer class for convert flstudio-news to JSON feed.
+ */
 export class JSONFeedTransformer {
   private baseUrl = "";
 
@@ -44,10 +47,21 @@ export class JSONFeedTransformer {
 
   private entries: string[] = [];
 
+  /**
+   * The constructor.
+   *
+   * @param {string} baseUrl - the base URL of JSON Feed,
+   * @returns {JSONFeedTransformer} - the instance of JSONFeedTransformer
+   */
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
   }
 
+  /**
+   * The dispatcher for `HTMLRewriter` elements.
+   *
+   * @param {Element} el - the `Element` object by `HTMLRewriter`
+   */
   element(el: Element) {
     const classNames = el.getAttribute("class");
 
@@ -149,6 +163,11 @@ export class JSONFeedTransformer {
     }
   }
 
+  /**
+   * The dispatcher for `HTMLRewriter` text.
+   *
+   * @param {Text} t - the `Text` object by `HTMLRewriter`.
+   */
   text(t: Text) {
     const text = t.text.replace(/^\s*|\s*$/g, "");
     if (text === "") {
@@ -193,6 +212,11 @@ export class JSONFeedTransformer {
     }
   }
 
+  /**
+   * Emit the current data to entries list.
+   *
+   * The state data is reset by this method.
+   */
   emitEntry() {
     const thumbnail =
       this.thumbnail !== "" ? `"banner_image": "${t(this.thumbnail)}",` : "";
@@ -223,6 +247,11 @@ export class JSONFeedTransformer {
     this.tags = [];
   }
 
+  /**
+   * Finalize entries data and emit JSON Feed string.
+   *
+   * @returns {string} - the JSON Feed string.
+   */
   finalize(): string {
     this.emitEntry();
 
@@ -243,6 +272,12 @@ export class JSONFeedTransformer {
 }`;
   }
 
+  /**
+   * Transform `REsponnse` object of flstudio-news page to JSON Feed string.
+   *
+   * @param {Response} input - the `Response` object fetched from flstudio-news page.
+   * @returns {Promise<string>} - the JSON Feed string by flstudio-news page.
+   */
   async transform(input: Response): Promise<string> {
     let rewriter = new HTMLRewriter();
 
@@ -271,6 +306,13 @@ export class JSONFeedTransformer {
   }
 }
 
+/**
+ * The transformer for flstudio-news page to JSON Feed.
+ *
+ * @param {Response} input - the `Response` object from flstudio-news page.
+ * @param {string} baseUrl - the base URL of JSON Feed.
+ * @returns {Promise<string>} - the JSON Feed string from flstudio-news page.
+ */
 export const transformToJSONFeed = (
   input: Response,
   baseUrl: string,

--- a/src/services/by-name/im/image-line/request.test.ts
+++ b/src/services/by-name/im/image-line/request.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { makeFLStudioNewRequest } from "./request";
+
+describe("flstudio-news/request", () => {
+  it("common test", () => {
+    const r = makeFLStudioNewRequest();
+
+    expect(r.method).toBe("GET");
+    expect(r.redirect).toBe("follow");
+    expect(r.headers.get("User-Agent")).toBeTruthy();
+  });
+
+  it("with User-Agent", () => {
+    const r = makeFLStudioNewRequest("example/0.01");
+
+    expect(r.headers.get("User-Agent")).toBe("example/0.01");
+  });
+});

--- a/src/services/by-name/im/image-line/request.ts
+++ b/src/services/by-name/im/image-line/request.ts
@@ -1,0 +1,1 @@
+export const FLStudioNewsUrl = "https://www.image-line.com/fl-studio-news";

--- a/src/services/by-name/im/image-line/request.ts
+++ b/src/services/by-name/im/image-line/request.ts
@@ -1,8 +1,17 @@
+/**
+ * The string of flstudio-news url.
+ */
 export const FLStudioNewsUrl = "https://www.image-line.com/fl-studio-news";
 
 const defaultDummyUserAgent =
   "Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0";
 
+/**
+ *  make the `Request` object for fetching to flstudio-news.
+ *
+ *  @param {string?} userAgent - the custom User-Agent string.
+ *  @returns {Request} - the `Request` object for `fetch` api.
+ */
 export const makeFLStudioNewRequest = (userAgent?: string): Request => {
   const dummaryUserAgent = userAgent ?? defaultDummyUserAgent;
   const request = new Request(FLStudioNewsUrl, {

--- a/src/services/by-name/im/image-line/request.ts
+++ b/src/services/by-name/im/image-line/request.ts
@@ -1,1 +1,17 @@
 export const FLStudioNewsUrl = "https://www.image-line.com/fl-studio-news";
+
+const defaultDummyUserAgent =
+  "Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0";
+
+export const makeFLStudioNewRequest = (userAgent?: string): Request => {
+  const dummaryUserAgent = userAgent ?? defaultDummyUserAgent;
+  const request = new Request(FLStudioNewsUrl, {
+    method: "GET",
+    redirect: "follow",
+    headers: {
+      "User-Agent": dummaryUserAgent,
+    },
+  });
+
+  return request;
+};


### PR DESCRIPTION
## Context

This pull request adds support to image-line's flstudio news.

## Status

- [ ] Draft
- [ ] Proposal
- [x] Approved
- [ ] Reject

## Decision

- Add support for flstudio-news page to json feed

## Effected Scope

- N/A