### PR TITLE
fix: fix to malformed escape on jsonfeed per services

### DIFF
--- a/src/services/by-name/im/image-line/parse.ts
+++ b/src/services/by-name/im/image-line/parse.ts
@@ -22,7 +22,7 @@ export const t = (src: string): string =>
         .replace(/\t+/g, " ")
         // biome-ignore lint/suspicious/noControlCharactersInRegex: this code remove unsafe string from `src`
         .replace(/[\u0000-\u001F]/g, "")
-        .replace(/(["'\\])/g, (_, p1) => `\\${p1}`)
+        .replace(/(["\\])/g, (_, p1) => `\\${p1}`)
     : "";
 
 /**

--- a/src/services/by-name/me/melonbooks/parse.ts
+++ b/src/services/by-name/me/melonbooks/parse.ts
@@ -22,7 +22,7 @@ export const t = (src: string): string =>
         .replace(/\t+/g, " ")
         // biome-ignore lint/suspicious/noControlCharactersInRegex: this code remove unsafe string from `src`
         .replace(/[\u0000-\u001F]/g, "")
-        .replace(/(["'\\])/g, (_, p1) => `\\${p1}`)
+        .replace(/(["\\])/g, (_, p1) => `\\${p1}`)
     : "";
 
 /**


### PR DESCRIPTION
## Context

Current code about escape json string makes to malformed string,
this pull request is fix it.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- Remove `'` char from escape string

## Effected Scope

- The output of escaped string changed
