### PR TITLE
refactor(lib): extract User-Agent string from service library

### DIFF
--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,0 +1,5 @@
+/**
+ * The UserAgent string from Firefox linux 141.0
+ */
+export const FirefoxForLinuxUserAgent =
+  "Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0";

--- a/src/services/by-name/im/image-line/request.ts
+++ b/src/services/by-name/im/image-line/request.ts
@@ -1,10 +1,9 @@
+import { FirefoxForLinuxUserAgent as defaultDummyUserAgent } from "@/lib/const";
+
 /**
  * The string of flstudio-news url.
  */
 export const FLStudioNewsUrl = "https://www.image-line.com/fl-studio-news";
-
-const defaultDummyUserAgent =
-  "Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0";
 
 /**
  *  make the `Request` object for fetching to flstudio-news.

--- a/src/services/by-name/me/melonbooks/request.ts
+++ b/src/services/by-name/me/melonbooks/request.ts
@@ -1,5 +1,4 @@
-const defaultDummyUserAgent =
-  "Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0";
+import { FirefoxForLinuxUserAgent as defaultDummyUserAgent } from "@/lib/const";
 
 /**
  * Make the `Request` object for fethcing melonbooks's circle page.


### PR DESCRIPTION
## Context

The current code defined User-Agent string per services,
but it should define to shared constants.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- Define shared constants string to `src/lib/const`
- Use shared constants from per services files

## Effected Scope

- Updated User-Agent string to some services
- All tests passed, but it has potencially risk to broken exists code
