### PR TITLE
feat(env): use `fence` as sandboxing tool on `nix develop` environment

### DIFF
--- a/.fence/bun.json
+++ b/.fence/bun.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@base",
+  "filesystem": {
+    "allowRead": ["~/.config/git/", "~/.ssh/id_ed25519.pub"],
+    "allowWrite": ["package.json", "bun.lock", "node_modules"],
+    "defaultDenyRead": true
+  },
+  "network": {
+    "allowedDomains": ["registry.npmjs.org", "*.npmjs.org"],
+    "allowedUnixSockets": ["/run/user/*/gnupg/S.gpg-agent.ssh"]
+  }
+}

--- a/.fence/git.json
+++ b/.fence/git.json
@@ -1,0 +1,33 @@
+{
+  "extends": "@base",
+  "filesystem": {
+    "allowGitConfig": true,
+    "allowRead": ["~/.config/git/", "~/.ssh/id_ed25519.pub"],
+    "allowExecute": [
+      ".husky",
+      ".husky/_",
+      "node_modules/.bin/biome",
+      "node_modules/.bin/commitlint",
+      "node_modules/.bin/oxlint",
+      "node_modules/.bin/textlint"
+    ],
+    "allowWrite": [".", ".git", "~/.ssh/known_hosts", "~/.ssh/known_hosts.old"],
+    "defaultDenyRead": true
+  },
+  "network": {
+    "allowedDomains": [
+      "github.com",
+      "gitlab.com",
+      "codeberg.org",
+      "api.github.com",
+      "codeload.github.com",
+      "lfs.github.com",
+      "objects.githubusercontent.com"
+    ],
+    "allowedUnixSockets": ["/run/user/*/gnupg/S.gpg-agent.ssh"]
+  },
+  "ssh": {
+    "allowAllCommands": true,
+    "allowedHosts": ["github.com", "gitlab.com", "codeberg.org"]
+  }
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,2 @@
-cat $1 | bun run textlint -- -c "$(dirname "${0}")/../textlintrc.yml" --stdin --stdin-filename "commit-msg.txt"
-bun run commitlint -- --edit $1
+cat $1 | node_modules/.bin/textlint -c "$(dirname "${0}")/../textlintrc.yml" --stdin --stdin-filename "commit-msg.txt"
+node_modules/.bin/commitlint -- --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-bun run biome format --write live
-bun run biome format --write src
+node_modules/.bin/biome format --write live
+node_modules/.bin/biome format --write src
 
-bun run biome check live src
+node_modules/.bin/biome check live src

--- a/flake.nix
+++ b/flake.nix
@@ -19,20 +19,25 @@
         devShells.default = pkgs.mkShell {
           name = "edgefeed";
           packages = with pkgs; [
-            bun
+            nodejs
+
+            fence
           ];
 
           shellHook = with pkgs; ''
             export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
 
-            sec-exec() {
-              # `sec` can take from https://github.com/nyarla/sec
-              env -i $(SEC_ENV=development sec env | grep -P "EDGEFEED_[A-Z]+=" ; echo PATH=$PATH ; echo SSL_CERT_FILE=$SSL_CERT_FILE) "''${@:-}"
-            }
+            export FENCE_SETTINGS_GIT=$(pwd)/.fence/git.json
+            export FENCE_SETTINGS_BUN=$(pwd)/.fence/bun.json
 
-            wrangler() {
-              sec-exec env CLOUDFLARE_INCLUDE_PROCESS_ENV=true bun run wrangler "''${@:-}"
-            }
+            export WRANGLER=$(pwd)/node_modules/.bin/wrangler
+
+            alias bun="${pkgs.lib.getExe pkgs.fence} --settings ''${FENCE_SETTINGS_BUN} -- ${pkgs.lib.getExe pkgs.bun}"
+            alias git="${pkgs.lib.getExe pkgs.fence} --settings ''${FENCE_SETTINGS_GIT} -- env PATH=${pkgs.gitFull}/bin:$PATH GIT_SSH_COMMAND='ssh -F /dev/null -o \"ProxyCommand=nc -X 5 -x 127.0.0.1:1080 %h %p\" ' git"
+
+            if command -v pass-cli ; then
+              alias wrangler="env -i PATH=''${PATH} TERM=''${TERM} pass-cli run --env-file .env -- env CLOUDFLARE_INCLUDE_PROCESS_ENV=true $WRANGLER"
+            fi
           '';
         };
       }


### PR DESCRIPTION
## Context

This is improvement to security for local development environment by `fence` sandboxing tool.

After the merged with a this pull request, `git` and `bun` are inside the `fence` sandbox.
It means `git` and `bun` commands restricted access to network or file-system by allowlist.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- Uses [fence](https://fencesandbox.com/) as sandboxing tool.
- Runs `git` and `bun` commands inside `fence` sandbox.

## Effected Scope

- This change effect to local development environment if `nix develop` used.

## Remarks

This pull request also includes to change the credential injector.

Before this pull request, this project uses a `sec` wrapper script for bitwarden secret manager, but now uses proton-pass-cli.

To use proton-pass-cli is optional. if your machine doesn't have `pass-cli`,  this feature does not activated.