### PR TITLE
refactor(fence): fix to bun with fence sandbox is not working

### DIFF
--- a/.fence/bun.json
+++ b/.fence/bun.json
@@ -2,7 +2,7 @@
   "extends": "@base",
   "filesystem": {
     "allowRead": ["~/.config/git/", "~/.ssh/id_ed25519.pub"],
-    "allowWrite": ["package.json", "bun.lock", "node_modules"],
+    "allowWrite": ["bun.lock", "node_modules", "~/.wrangler/logs"],
     "defaultDenyRead": true
   },
   "network": {

--- a/.fence/bun.json
+++ b/.fence/bun.json
@@ -2,7 +2,12 @@
   "extends": "@base",
   "filesystem": {
     "allowRead": ["~/.config/git/", "~/.ssh/id_ed25519.pub"],
-    "allowWrite": ["bun.lock", "node_modules", "~/.wrangler/logs"],
+    "allowWrite": [
+      "bun.lock",
+      "node_modules",
+      "package.json",
+      "~/.wrangler/logs"
+    ],
     "defaultDenyRead": true
   },
   "network": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,28 +14,56 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        fence-exec = pkgs.writeShellScriptBin "fence-exec" ''
+          rule="$1"
+          shift
+
+          temporary="$(mktemp)"
+          finalized="$(mktemp)"
+
+          trap 'rm $temporary $finalized' EXIT INT PIPE TERM
+
+          C="$(pwd)"
+          D=""
+
+          (
+            echo '['
+            echo $C | while read -d "/" P ; do
+              if [[ $P != "" ]]; then
+                D="$D/$P"
+                echo \"$D\",
+              fi
+            done
+            echo \"$C\"
+            echo ']'
+          ) > $temporary
+
+          ${with pkgs; lib.getExe jq} '.filesystem.allowRead += input' $rule $temporary > $finalized
+          ${with pkgs; lib.getExe fence} --settings $finalized "''${@:-}"
+        '';
       in
       {
         devShells.default = pkgs.mkShell {
           name = "edgefeed";
-          packages = with pkgs; [
-            nodejs
+          packages =
+            (with pkgs; [
+              nodejs
 
-            fence
-          ];
+              fence
+            ])
+            ++ [ fence-exec ];
 
           shellHook = with pkgs; ''
             export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
 
-            export FENCE_SETTINGS_GIT=$(pwd)/.fence/git.json
             export FENCE_SETTINGS_BUN=$(pwd)/.fence/bun.json
+            export FENCE_SETTINGS_GIT=$(pwd)/.fence/git.json
 
-            export WRANGLER=$(pwd)/node_modules/.bin/wrangler
+            alias git="${lib.getExe fence} --settings ''${FENCE_SETTINGS_GIT} -- env PATH=${gitFull}/bin:$PATH GIT_SSH_COMMAND='ssh -F /dev/null -o \"ProxyCommand=nc -X 5 -x 127.0.0.1:1080 %h %p\" ' git"
+            alias bun="fence-exec ''${FENCE_SETTINGS_BUN} -- ${lib.getExe bun}"
 
-            alias bun="${pkgs.lib.getExe pkgs.fence} --settings ''${FENCE_SETTINGS_BUN} -- ${pkgs.lib.getExe pkgs.bun}"
-            alias git="${pkgs.lib.getExe pkgs.fence} --settings ''${FENCE_SETTINGS_GIT} -- env PATH=${pkgs.gitFull}/bin:$PATH GIT_SSH_COMMAND='ssh -F /dev/null -o \"ProxyCommand=nc -X 5 -x 127.0.0.1:1080 %h %p\" ' git"
-
-            if command -v pass-cli ; then
+            if command -v pass-cli >/dev/null 2>&1; then
               alias wrangler="env -i PATH=''${PATH} TERM=''${TERM} pass-cli run --env-file .env -- env CLOUDFLARE_INCLUDE_PROCESS_ENV=true $WRANGLER"
             fi
           '';


### PR DESCRIPTION
## Context

`bun` command does not work inside `fence` sandbox at the current code, so this pull request is fixed to this issue.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- Merges temporary rules to the static rules.
- This behaviour is implemented by `fence-exec` shell script.
- These scripts defined on `flake.nix`

## Effected Scope

- The chages to experience on `nix develop` development environment.
