### PR TITLE
refactor(common): add more supporting for URL format

### DIFF
--- a/src/Common/URL.test.ts
+++ b/src/Common/URL.test.ts
@@ -9,7 +9,12 @@ describe("normalizeURL", () => {
     expect(result?.toString()).toBe("https://www.example.com/foo/image.jpg");
   });
 
-  it("should handle an absolute URL as src", () => {
+  it("should resolve a relative path started with `/` against a base URL", () => {
+    const result = normalizeURL(baseUrl, "/image.png");
+    expect(result?.toString()).toBe("https://www.example.com/image.png");
+  });
+
+  it("should resolve a absolute path as URL", () => {
     const result = normalizeURL(
       baseUrl,
       "https://another.example.com/bar/image.jpg",
@@ -19,14 +24,27 @@ describe("normalizeURL", () => {
     );
   });
 
-  it("should return null if src is null or undefined", () => {
+  it("should handle absolute URI without protocol scheme", () => {
+    const result = normalizeURL(baseUrl, "//example.com/image.jpg");
+    expect(result?.toString()).toBe("https://example.com/image.jpg");
+  });
+
+  it("should handle absolute path without hostname", () => {
+    const result = normalizeURL(baseUrl, "/bar/image.jpg");
+    expect(result?.toString()).toBe("https://www.example.com/bar/image.jpg");
+  });
+
+  it("should handle number sign as link pointer", () => {
+    const result = normalizeURL(baseUrl, "#foo");
+    expect(result?.toString()).toBe("https://www.example.com/foo#foo");
+  });
+
+  it("should return null if url string is null or undefined", () => {
     expect(normalizeURL(baseUrl, null)).toBeNull();
     expect(normalizeURL(baseUrl, undefined)).toBeNull();
   });
 
   it("should return null for invalid URL inputs", () => {
     expect(normalizeURL("/not-a-url", "example.com/")).toBeNull();
-    expect(normalizeURL("#not-a-url", "https://www.example.com/")).toBeNull();
-    expect(normalizeURL("//not-a-url", "https://www.example.com/")).toBeNull();
   });
 });

--- a/src/Common/URL.ts
+++ b/src/Common/URL.ts
@@ -14,6 +14,23 @@ export const normalizeURL = (
   }
 
   try {
+    if (src.startsWith("https://") || src.startsWith("http://")) {
+      return new URL(src);
+    }
+
+    if (src.startsWith("//")) {
+      return new URL(`https:${src}`);
+    }
+
+    if (src.startsWith("/")) {
+      const base = new URL(baseUrl);
+      return new URL(`${base.protocol}//${base.hostname}${src}`);
+    }
+
+    if (src.startsWith("#")) {
+      return new URL(`${baseUrl}${src}`);
+    }
+
     return new URL(src, baseUrl);
   } catch (_: unknown) {
     return null;


### PR DESCRIPTION
## Context

This pull request adds more support for the URL format.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

`normalizeURL` now supports these format:

```
const baseURL = 'https://example.com/foo';

console.log(normalizeURL(baseURL, '//www.example.com').toString()); // => https://www.example.com
console.log(normalizeURL(baseURL, '/bar').toString()); // => https://example.com/bar
console.log(normalizeURL(baseURL, '#baz').toString()); // => https://example.com/bar#baz
```

## Effected Scope

`normalizeURL` has changed its behavior for parsing URLs, which may or may not break old behavior depending on your code.
