### PR TITLE
refactor(common): split SwitchScopeHandler into EnterScopeHandler and EndScopeHandler

### DIFF
--- a/src/Common/Handlers.test.ts
+++ b/src/Common/Handlers.test.ts
@@ -2,10 +2,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Emitter } from "./Emitter";
 import {
   BufferedStringHandler,
+  EndScopeHandler,
+  EnterScopeHandler,
   IncrementScopeIdHandler,
   StaticStringHandler,
   StringAttributeHandler,
-  SwitchScopeHandler,
   URLAttributeHandler,
 } from "./Handlers";
 import { ParserContext } from "./ParserContext";
@@ -242,16 +243,16 @@ describe("Handlers", () => {
     });
   });
 
-  describe("SwitchScopeHandler", () => {
-    it("should switch to the specified context scope if the element is found", async () => {
-      const parentScope = new SwitchScopeHandler<Scope>({
-        type: "SwitchScope",
+  describe("EnterScopeHandler", () => {
+    it("should enter the specified context scope if the element is found", async () => {
+      const parentScope = new EnterScopeHandler<Scope>({
+        type: "EnterScope",
         pc,
         scope: "parent",
       });
 
-      const childScope = new SwitchScopeHandler<Scope>({
-        type: "SwitchScope",
+      const childScope = new EnterScopeHandler<Scope>({
+        type: "EnterScope",
         pc,
         scope: "child",
       });
@@ -274,6 +275,42 @@ describe("Handlers", () => {
       expect(JSON.parse(emitter.toString())).toStrictEqual({
         parent: [{ value: "new scope" }],
         child: [{ value: "new scope" }],
+      });
+    });
+  });
+
+  describe("EndScopeHandler", () => {
+    it("should exit the current context scope if the element is found", async () => {
+      const enterScope = new EnterScopeHandler<Scope>({
+        type: "EnterScope",
+        pc,
+        scope: "parent",
+      });
+
+      const endScope = new EndScopeHandler<Scope>({
+        type: "EndScope",
+        pc,
+      });
+
+      const staticValue = new StaticStringHandler<Scope, Prop>({
+        type: "StaticString",
+        emitter,
+        pc,
+        prop: "value",
+        value: "new scope",
+      });
+
+      rewriter.on("p.msg", enterScope);
+      rewriter.on("p.msg", staticValue);
+
+      rewriter.on("p.nest", endScope);
+      rewriter.on("p.nest", staticValue);
+
+      await rewriter.transform(src).arrayBuffer();
+
+      expect(JSON.parse(emitter.toString())).toStrictEqual({
+        root: [{ value: "new scope" }],
+        parent: [{ value: "new scope" }],
       });
     });
   });

--- a/src/Common/Handlers.ts
+++ b/src/Common/Handlers.ts
@@ -30,15 +30,22 @@ export type ExtractHandlerConfig<Scope extends string, Prop extends string> =
       value: string;
     }
   | {
-      type: "SwitchScope";
+      type: "EnterScope";
       scope: Scope;
+    }
+  | {
+      type: "EndScope";
     }
   | {
       type: "IncrementScopeId";
     };
 
 export type ExtractHandlerArgs<Scope extends string, Prop extends string> =
-  | (({ type: "SwitchScope" } | { type: "IncrementScopeId" }) &
+  | ((
+      | { type: "EnterScope" }
+      | { type: "EndScope" }
+      | { type: "IncrementScopeId" }
+    ) &
       ExtractHandlerConfig<Scope, Prop> & {
         pc: ParserContext<Scope>;
       })
@@ -213,25 +220,36 @@ export class StaticStringHandler<Scope extends string, Prop extends string>
   text(_: Text) {}
 }
 
-export class SwitchScopeHandler<Scope extends string>
-  implements ExtractHandler
-{
+export class EnterScopeHandler<Scope extends string> implements ExtractHandler {
   private pc!: ParserContext<Scope>;
   private scope!: Scope;
 
   constructor({
     pc,
     scope,
-  }: { type: "SwitchScope" } & ExtractHandlerArgs<Scope, string>) {
+  }: { type: "EnterScope" } & ExtractHandlerArgs<Scope, string>) {
     this.pc = pc;
     this.scope = scope;
   }
 
-  element(el: Element) {
+  element(_: Element) {
     this.pc.enterScope(this.scope);
-    el.onEndTag(() => {
-      this.pc.endScope();
-    });
+  }
+
+  text(_: Text) {}
+}
+
+export class EndScopeHandler<Scope extends string> implements ExtractHandler {
+  private pc!: ParserContext<Scope>;
+
+  constructor({
+    pc,
+  }: { type: "EndScope" } & ExtractHandlerArgs<Scope, string>) {
+    this.pc = pc;
+  }
+
+  element(_: Element) {
+    this.pc.endScope();
   }
 
   text(_: Text) {}
@@ -296,10 +314,16 @@ export const createExtractHandlers = <
           new StaticStringHandler<Scope, Prop>({ emitter, pc, ...config }),
         ]);
         break;
-      case "SwitchScope":
+      case "EnterScope":
         registry.push([
           selector,
-          new SwitchScopeHandler<Scope>({ pc, ...config }),
+          new EnterScopeHandler<Scope>({ pc, ...config }),
+        ]);
+        break;
+      case "LeaveScope":
+        registry.push([
+          selector,
+          new EnterScopeHandler<Scope>({ pc, ...config }),
         ]);
         break;
       case "IncrementScopeId":


### PR DESCRIPTION
## Context

This pull request splits the SwitchScopeHandler into EnterScopeHandler and EndScopeHandler.

The old SwitchScopeHandler threw an error if an HTML element had no closing tag, but that happened occasionally.

This approach addresses the issue by splitting the switch scope into enter scope and end scope.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- Splits the `SwitchScopeHandler` into `EnterScopeHandler` and `EndScopeHandler`

## Effected Scope

The old `SwitchScopeHandler` has been removed. This is a breaking change for users of `SwitchScopeHandler`.