### PR TITLE
feat(cache): add Cache classes using Cloudflares's `caches.open` and R2

### DIFF
--- a/src/Cache/Cache.d.ts
+++ b/src/Cache/Cache.d.ts
@@ -1,0 +1,11 @@
+import { Context } from "hono";
+
+export interface CachesConstructor {
+  new (c: Context, ns: string): Caches;
+}
+
+export interface CacheInterface {
+  match: (key: Request) => Promise<Response | undefined>;
+  put: (key: Request, val: Response) => Promise<void>;
+  delete: (key: Request) => Promise<boolean>;
+}

--- a/src/Cache/CloudflareR2Cache.test.ts
+++ b/src/Cache/CloudflareR2Cache.test.ts
@@ -1,0 +1,76 @@
+import {
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import {
+  CloudflareR2Cache,
+  type CloudflareR2CacheBindings,
+} from "./CloudflareR2Cache";
+
+describe("CloudflareR2Cache", async () => {
+  const app = new Hono<{ Bindings: CloudflareR2CacheBindings }>();
+  app.get("/", async (c) => {
+    const cache = new CloudflareR2Cache(c, "test");
+    const key = new Request("https://localhost", {
+      method: "GET",
+    });
+
+    const data = await cache.match(key);
+    if (!data) {
+      const value = new Response("ok", {
+        status: 200,
+        headers: {
+          "Cache-Control": "max-age=3600",
+        },
+      });
+      await cache.put(key, value);
+      return c.text("miss");
+    }
+
+    return c.text(await data.text());
+  });
+
+  app.get("/delete", async (c) => {
+    const cache = new CloudflareR2Cache(c, "test");
+    const key = new Request("https://localhost", { method: "GET" });
+
+    const data = await cache.match(key);
+    if (data) {
+      await cache.delete(key);
+      return c.text("deleted");
+    }
+
+    return c.text("miss");
+  });
+
+  it("should cache the data on the first request, and return cached data on the second request", async () => {
+    const first = createExecutionContext();
+    const miss = await app.request("/", {}, env, first);
+    waitOnExecutionContext(first);
+
+    expect(await miss?.text()).toBe("miss");
+
+    const second = createExecutionContext();
+    const ok = await app.request("/", {}, env, second);
+    waitOnExecutionContext(second);
+
+    expect(await ok?.text()).toBe("ok");
+  });
+
+  it("should delete cached data", async () => {
+    const first = createExecutionContext();
+    const deleted = await app.request("/delete", {}, env, first);
+    waitOnExecutionContext(first);
+
+    expect(await deleted?.text()).toBe("deleted");
+
+    const second = createExecutionContext();
+    const miss = await app.request("/delete", {}, env, second);
+    waitOnExecutionContext(second);
+
+    expect(await miss?.text()).toBe("miss");
+  });
+});

--- a/src/Cache/CloudflareR2Cache.ts
+++ b/src/Cache/CloudflareR2Cache.ts
@@ -1,0 +1,81 @@
+import type { Context } from "hono";
+import type { CacheInterface, CachesConstructor } from "./Cache";
+
+export type CloudflareR2CacheBindings = {
+  EDGEFEED_CACHE_R2_BUCKET: R2Bucket;
+  EDGEFEED_CACHE_R2_EXPIRY: number;
+};
+
+export const CloudflareR2Cache: CachesConstructor = class CloudflareR2Cache
+  implements CacheInterface
+{
+  private r2!: R2Bucket;
+  private expiry!: number;
+  private ns!: string;
+
+  constructor(c: Context, ns: string) {
+    this.ns = ns;
+    this.r2 = c.env.EDGEFEED_CACHE_R2_BUCKET;
+    this.expiry = c.env.EDGEFEED_CACHE_R2_EXPIRY;
+  }
+
+  cacheKey(r: Request) {
+    const href = new URL(r.url);
+    const domain = href.hostname.split(".").reverse().join(".");
+    const path = href.pathname;
+    const query = href.searchParams.toString();
+
+    return `${this.ns}/${domain}/${path}${query ? `?${query}` : ""}`;
+  }
+
+  async match(r: Request): Promise<Response | undefined> {
+    const key = this.cacheKey(r);
+    const data = await this.r2.get(key);
+
+    if (!data) {
+      return undefined;
+    }
+
+    if ("body" in data) {
+      const expiry = data.uploaded.valueOf() + this.expiry;
+      const now = Date.now();
+
+      if (expiry < now) {
+        await this.delete(r);
+        return undefined;
+      }
+
+      const status = 200;
+      const headers = new Headers();
+
+      data.writeHttpMetadata(headers);
+
+      return new Response(data.body, { status, headers });
+    }
+
+    return undefined;
+  }
+
+  async put(r: Request, val: Response): Promise<void> {
+    const key = this.cacheKey(r);
+    const { body, headers } = val;
+
+    return this.r2.put(key, body, { httpMetadata: headers }).then(() => {
+      return;
+    });
+  }
+
+  async delete(r: Request): Promise<boolean> {
+    const key = this.cacheKey(r);
+    const data = await this.r2.get(key);
+    if (!data) {
+      return false;
+    }
+
+    if ("body" in data) {
+      return this.r2.delete(key).then(() => true);
+    }
+
+    return false;
+  }
+};

--- a/src/Cache/CloudflareWorkersCache.test.ts
+++ b/src/Cache/CloudflareWorkersCache.test.ts
@@ -1,0 +1,73 @@
+import {
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { CloudflareWorkersCache } from "./CloudflareWorkersCache";
+
+describe("CloudflareWorkersCache", async () => {
+  const app = new Hono();
+  app.get("/", async (c) => {
+    const cache = new CloudflareWorkersCache(c, "test");
+    const key = new Request("https://localhost", {
+      method: "GET",
+    });
+
+    const data = await cache.match(key);
+    if (!data) {
+      const value = new Response("ok", {
+        status: 200,
+        headers: {
+          "Cache-Control": "max-age=3600",
+        },
+      });
+      await cache.put(key, value);
+      return c.text("miss");
+    }
+
+    return c.text(await data.text());
+  });
+
+  app.get("/delete", async (c) => {
+    const cache = new CloudflareWorkersCache(c, "test");
+    const key = new Request("https://localhost", { method: "GET" });
+
+    const data = await cache.match(key);
+    if (data) {
+      await cache.delete(key);
+      return c.text("deleted");
+    }
+
+    return c.text("miss");
+  });
+
+  it("should cache the data on the first request, and return cached data on the second request", async () => {
+    const first = createExecutionContext();
+    const miss = await app.request("/", {}, env, first);
+    waitOnExecutionContext(first);
+
+    expect(await miss?.text()).toBe("miss");
+
+    const second = createExecutionContext();
+    const ok = await app.request("/", {}, env, second);
+    waitOnExecutionContext(second);
+
+    expect(await ok?.text()).toBe("ok");
+  });
+
+  it("should delete cached data", async () => {
+    const first = createExecutionContext();
+    const deleted = await app.request("/delete", {}, env, first);
+    waitOnExecutionContext(first);
+
+    expect(await deleted?.text()).toBe("deleted");
+
+    const second = createExecutionContext();
+    const miss = await app.request("/delete", {}, env, second);
+    waitOnExecutionContext(second);
+
+    expect(await miss?.text()).toBe("miss");
+  });
+});

--- a/src/Cache/CloudflareWorkersCache.ts
+++ b/src/Cache/CloudflareWorkersCache.ts
@@ -1,0 +1,33 @@
+import type { Context } from "hono";
+import type { CacheInterface, CachesConstructor } from "./Cache";
+
+export const CloudflareWorkersCache: CachesConstructor = class CloudflareWorkersCache
+  implements CacheInterface
+{
+  private ns!: string;
+  private cache!: Cache;
+
+  constructor(_: Context, ns: string) {
+    this.ns = ns;
+  }
+
+  async open(): Promise<Cache> {
+    if (!this.cache) {
+      this.cache = await caches.open(this.ns);
+    }
+
+    return this.cache;
+  }
+
+  async put(key: Request, val: Response): Promise<void> {
+    return (await this.open()).put(key, val);
+  }
+
+  async match(key: Request): Promise<Response | undefined> {
+    return (await this.open()).match(key);
+  }
+
+  async delete(key: Request): Promise<boolean> {
+    return (await this.open()).delete(key);
+  }
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,12 +5,12 @@
   "compatibility_date": "2025-03-16",
   "r2_buckets": [
     {
-      "binding": "EDGEFEED_R2_CACHE_BUCKET",
+      "binding": "EDGEFEED_CACHE_R2_BUCKET",
       "bucket_name": "edgefeed-r2-cache"
     }
   ],
   "vars": {
-      "EDGEFEED_R2_CACHE_DURATION": 2000,
+      "EDGEFEED_CACHE_R2_EXPIRY": 2000,
       "EDGEFEED_TOKEN_AUTH_TOKEN": "ABC12345"
   }
   // "compatibility_flags": [


### PR DESCRIPTION
## Context

This pull request adds Cache classes using Cloudflare's `caches.open` and R2 storage.

## Status

- [ ] Draft
- [x] Proposal
- [ ] Approved
- [ ] Reject

## Decision

- Add Cache classes using Cloudflare's `caches.open` and R2 storage
- This pull request updated `wrangler.jsonc`, which broke existing code

## Effected Scope

- If existing code depends on `wralnger.jsonc`, it will be broken by this pull request.